### PR TITLE
Add another dir for custom folder on Linux

### DIFF
--- a/installation.txt
+++ b/installation.txt
@@ -11,6 +11,10 @@ C:\Program Files (x86)\Steam\steamapps\common\Team Fortress 2\tf\custom\
 
 If you are on Linux, this may be found in:
 ~/.steam/steam/steamapps/common/Team Fortress 2/tf/custom/
+an alternative path may be:
+~/.local/share/steam/steamapps/common/Team Fortress 2/tf/custom/
+
+(where ~ is your home directory)
 
 NOTE: On Linux, the voidHUD2.0 directory MUST be in lowercase (so, "voidhud2.0").
 


### PR DESCRIPTION
This seems to be the default install directory on Ubuntu installations, at least it was for me.
